### PR TITLE
[COOK-2339] Make slapd.conf complete configurable with attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,7 +24,7 @@ if node['domain'].length > 0
   default['openldap']['server'] = "ldap.#{node['domain']}"
 end
 
-openldap['rootpw'] = nil
+default['openldap']['rootpw'] = nil
 
 # File and directory locations for openldap.
 case node['platform']
@@ -46,11 +46,84 @@ default['openldap']['ssl_dir'] = "#{openldap['dir']}/ssl"
 default['openldap']['cafile']  = "#{openldap['ssl_dir']}/ca.crt"
 default['openldap']['slapd_type'] = nil
 
+default['openldap']['slapd_schema'] = [
+  'core',
+  'cosine',
+  'nis',
+  'inetorgperson'
+]
+
+default['openldap']['slapd_modules'] = [
+  'back_hdb'
+]
+
 if node['openldap']['slapd_type'] == "slave"
   default['openldap']['slapd_master'] = node['openldap']['server']
   default['openldap']['slapd_replpw'] = nil
   default['openldap']['slapd_rid']    = 102
 end
+
+default['openldap']['slapd_loglevel'] = 0
+default['openldap']['slapd_sizelimit'] = 500
+default['openldap']['slapd_tool-threads'] = 1
+
+
+default['openldap']['slapd_options'] = {}
+
+
+# database config
+
+default['openldap']['slapd_databases']['default']['type'] = 'hdb'
+# set database options to nil, means use global ones, backward compatibility
+default['openldap']['slapd_databases']['default']['suffix'] = nil
+default['openldap']['slapd_databases']['default']['rootdn'] = nil
+default['openldap']['slapd_databases']['default']['rootpw'] = nil
+# default values
+default['openldap']['slapd_databases']['default']['directory'] = "/var/lib/ldap"
+default['openldap']['slapd_databases']['default']['lastmod'] = "on"
+
+
+default['openldap']['slapd_databases']['default']['options']['dbconfig'] = [
+  'set_cachesize 0 31457280 0',
+  # Number of objects that can be locked at the same time.
+  'set_lk_max_objects 1500',
+  # Number of locks (both requested and granted)
+  'set_lk_max_locks 1500',
+  # Number of lockers
+  'set_lk_max_lockers 1500'
+]
+
+default['openldap']['slapd_acls'] = {
+  "00" => {
+    "attrs" => "userPassword,shadowLastChange",
+    "access" => {
+      "00" => { "group.exact" =>"cn=administrators,#{node['openldap']['basedn']}", "action" => "write" },
+      "10" => { "dn" => "cn=syncrole,#{node['openldap']['basedn']}", "action" => "read" },
+      "20" => { "anonymous" => true, "action" => "auth" },
+      "30" => { "self" => true, "action" => "write" },
+      "40" => "none"
+    }
+  },
+  "10" => {
+    "dn" => "",
+    "dntype" => "base",
+    "access" => "read",
+  },
+  "20" => {
+    "access" => {
+      "00" => { "group.exact" => "cn=administrators,#{node['openldap']['basedn']}", "action" => "write" },
+      "10" => { "dn" => "cn=syncrole,#{node['openldap']['basedn']}", "action" => "read" },
+      "20" => "read"
+    }
+  }
+}
+
+
+default['openldap']['slapd_databases']['default']['indexes']['default'] = 'pres,eq,approx,sub'
+default['openldap']['slapd_databases']['default']['indexes']['objectClass'] = 'eq'
+default['openldap']['slapd_databases']['default']['indexes']['cn,ou,sn,uid,l,mail,gecos,memberUid,description'] = '' # means default
+default['openldap']['slapd_databases']['default']['indexes']['loginShell,homeDirectory'] = 'pres,eq,approx'
+default['openldap']['slapd_databases']['default']['indexes']['uidNumber,gidNumber'] = 'pres,eq'
 
 # Auth settings for Apache
 if node['openldap']['basedn'] && node['openldap']['server']

--- a/libraries/acl.rb
+++ b/libraries/acl.rb
@@ -1,0 +1,71 @@
+#
+# Author:: Malte Swart (<chef@malteswart.de>)
+# Cookbook Name:: openldap
+#
+# Copyright 2013, Opscode, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef::Node
+  def generate_openldap_acls_from_attributes
+    self['openldap']['slapd_acls'].sort.inject([]) do |acl, (priority, aclMesh)|
+      next acl if aclMesh.nil? # skipping because entry was removed
+      # build what string
+      what = [ 'to' ]
+      unless aclMesh['dn'].nil?
+        what << unless aclMesh['dntype'].nil?
+          "dn=\"#{aclMesh['dn']}\""
+        else
+          "dn.#{aclMesh['dntype']}=\"#{aclMesh['dn']}\""
+        end
+      end
+      unless aclMesh['filter'].nil?
+        what << "filter=#{aclMesh['filter']}"
+      end
+      unless aclMesh['attrs'].nil?
+        what << "attrs=#{aclMesh['attrs']}"
+      end
+      if what.size == 1
+        what << '*'
+      end
+      accessLines = generate_openldap_acls_access_lines aclMesh['access']
+      acl << [ what.join(' '), accessLines ]
+    end
+  end
+
+  def generate_openldap_acls_access_lines(accessMesh)
+    return [ "by * #{accessMesh}" ] if accessMesh.kind_of? String
+    accessMesh.sort.inject([]) do |accessLines, (priority, accessEntry)|
+      if accessEntry.kind_of? String # shortcut for by * <action>
+        next accessLines << "by * #{accessEntry}"
+      end
+      # map all test=>testvalue
+      accessLine = accessEntry.keys.inject(['by']) do |lines, key|
+        next lines if %w{action control}.include? key.to_s
+        lines << if accessEntry[key] == true # speci group like self, users
+          key
+        else
+          "#{key}=\"#{accessEntry[key]}\""
+        end
+      end
+      # add action
+      accessLine << accessEntry['action']
+      # add control key words
+      unless accessEntry['control'].nil?
+        accessLine << accessEntry['control']
+      end
+      accessLines << accessLine.join(' ')
+    end
+  end
+end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -80,6 +80,7 @@ if (node['platform'] == "ubuntu")
     mode 00640
     owner "openldap"
     group "openldap"
+    variables :acl => node.generate_openldap_acls_from_attributes
     notifies :stop, resources(:service => "slapd"), :immediately
     notifies :run, resources(:execute => "slapd-config-convert")
   end
@@ -99,6 +100,7 @@ else
     mode 00640
     owner "openldap"
     group "openldap"
+    variables :acl => node.generate_openldap_acls_from_attributes
     notifies :restart, resources(:service => "slapd")
   end
 end

--- a/templates/default/slapd.conf.erb
+++ b/templates/default/slapd.conf.erb
@@ -12,10 +12,13 @@ TLSCertificateFile     <%= node['openldap']['dir'] %>/ssl/<%= node['openldap']['
 TLSCertificateKeyFile  <%= node['openldap']['dir'] %>/ssl/<%= node['openldap']['server'] %>.pem
 
 # Schema and objectClass definitions
-include         <%= node['openldap']['dir'] %>/schema/core.schema
-include         <%= node['openldap']['dir'] %>/schema/cosine.schema
-include         <%= node['openldap']['dir'] %>/schema/nis.schema
-include         <%= node['openldap']['dir'] %>/schema/inetorgperson.schema
+<% node['openldap']['slapd_schema'].each do |schema| -%>
+<% if schema[0] == '/' %>
+include         <%= schema %>
+<% else %>
+include         <%= node['openldap']['dir'] %>/schema/<%= schema %>.schema
+<% end %>
+<% end -%>
 
 # Where the pid file is put. The init.d script
 # will not stop the server if you change this.
@@ -25,23 +28,37 @@ pidfile         <%= node['openldap']['run_dir'] %>/slapd.pid
 argsfile        <%= node['openldap']['run_dir'] %>/slapd.args
 
 # Read slapd.conf(5) for possible values
-loglevel        0
+loglevel        <%= node['openldap']['slapd_loglevel'] %>
 
 <% unless node['platform'] == "centos" -%>
 # Where the dynamically loaded modules are stored
 modulepath	<%= node['openldap']['module_dir'] %>
-moduleload	back_hdb
 <% if node['openldap']['slapd_type'] == "master" -%>
 moduleload  syncprov
+<% end -%>
+<% node['openldap']['slapd_modules'].each do |modulename| -%>
+moduleload  <%= modulename %>
 <% end -%>
 <% end -%>
 
 # The maximum number of entries that is returned for a search operation
-sizelimit 500
+sizelimit <%= node['openldap']['slapd_sizelimit'] %>
 
 # The tool-threads parameter sets the actual amount of cpu's that is used
 # for indexing.
-tool-threads 1
+tool-threads <%= node['openldap']['slapd_tool-threads'] %>
+
+
+######
+# ACLS
+######
+
+<% @acl.each do |acl| %>
+access <%= acl[0] %>
+<% acl[1].each do |entry| %>
+  <%= entry %>
+<% end -%>
+<% end -%>
 
 #######################################################################
 # Specific Backend Directives for hdb:
@@ -50,32 +67,41 @@ tool-threads 1
 backend		hdb
 
 #####
-# Database
+# Databases
 #####
-database        hdb
-suffix          "<%= node['openldap']['basedn'] %>"
-rootdn          "cn=admin,<%= node['openldap']['basedn'] %>"
-rootpw		      <%= node['openldap']['rootpw'] %>
-directory       "/var/lib/ldap"
-lastmod         on
-
-dbconfig set_cachesize 0 31457280 0
-
-# Number of objects that can be locked at the same time.
-dbconfig set_lk_max_objects 1500
-# Number of locks (both requested and granted)
-dbconfig set_lk_max_locks 1500
-# Number of lockers
-dbconfig set_lk_max_lockers 1500
+<% node['openldap']['slapd_databases'].sort.each do |name, database| -%>
+database        <%= database['type']%>
+suffix          <%= database['suffix'] || node['openldap']['basedn'] %>
+rootdn          <%= database['rootdn'] || "cn=admin,#{node['openldap']['basedn']}" %>
+rootpw          <%= database['rootpw'] || node['openldap']['rootpw'] %>
+directory       <%= database['directory'] %>
+lastmod         <%= database['lastmod'] %>
 
 ##
 # Indexes
 ##
-index default pres,eq,approx,sub
-index objectClass eq
-index cn,ou,sn,uid,l,mail,gecos,memberUid,description
-index loginShell,homeDirectory pres,eq,approx
-index uidNumber,gidNumber pres,eq
+<% unless (database['indexes'] || {})['default'].nil? %>
+index default <%= database['indexes']['default'] %>
+<% end -%>
+<% (database['indexes'] || {}).sort.each do |attributes, options| -%>
+<% next if attributes == 'default' || options.nil? || options == false -%>
+index <%= attributes %> <%= options == true ? '' : options %>
+<% end -%>
+
+# Other options
+
+<% (database['options'] || {}).sort.each do |option, value| -%>
+<% if value.kind_of? Array %>
+<% value.each do |singlevalue| %>
+<%= option %> <%= singlevalue %>
+<% end -%>
+<% else -%>
+<%= option %> <%= value %>
+<% end -%>
+<% end -%>
+
+<% end -%>
+### END Databases
 
 <% if node['openldap']['slapd_type'] == "master" -%>
 overlay syncprov
@@ -95,32 +121,13 @@ syncrepl rid=<%= node['openldap']['slapd_rid'] %>
   starttls=yes
   credentials="<%= node['openldap']['slapd_replpw'] %>"
 <% end -%>
-# The userPassword by default can be changed
-# by the entry owning it if they are authenticated.
-# Others should not be able to see it, except the
-# admin entry below
-# These access lines apply to database #1 only
-access to attrs=userPassword,shadowLastChange
-        by group.exact="cn=administrators,<%= node['openldap']['basedn'] %>" write
-        by dn="cn=syncrole,<%= node['openldap']['basedn'] %>" read
-        by anonymous auth
-        by self write
-        by * none
 
-# Ensure read access to the base for things like
-# supportedSASLMechanisms.  Without this you may
-# have problems with SASL not knowing what
-# mechanisms are available and the like.
-# Note that this is covered by the 'access to *'
-# ACL below too but if you change that as people
-# are wont to do you'll still need this if you
-# want SASL (and possible other things) to work
-# happily.
-access to dn.base="" by * read
-
-# The admin dn has full write access, everyone else
-# can read everything.
-access to *
-        by group.exact="cn=administrators,<%= node['openldap']['basedn'] %>" write
-        by dn="cn=syncrole,<%= node['openldap']['basedn'] %>" read
-        by * read
+<% (node['openldap']['slapd_options'] || {}).sort.each do |option, value| -%>
+<% if value.kind_of? Array %>
+<% value.each do |singlevalue| %>
+<%= option %> <%= singlevalue %>
+<% end -%>
+<% else -%>
+<%= option %> <%= value %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-2339

The cookbook has only a few options which allow changes of openldap service configuration (`slapd.conf`). So in most cases cookbook/templates changes are needed to adjust openldap to your own needs.

All hard-coded values from the template should be replaced by node attributes (with default values). A generic attribute hash should allow setting of additional (for the cookbook unknown) config options.