### PR TITLE
[COOK-4499] Updated README to correctly refer to the attribute as openld...

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Be aware of the attributes used by this cookbook and adjust the defaults for you
    If set to `false`, you will need to provide your SSL certificates **prior** to this recipe being run. Be sure to set `openldap[:ssl_cert]` and `openldap[:ssl_key]` appropriately.
 - `openldap[:ssl_cert]` - The full path to your SSL certificate.
 - `openldap[:ssl_key]` - The full path to your SSL key.
-- `openldap[:cacert]` - Your certificate authority's certificate (or intermediate authorities), if needed.
+- `openldap[:cafile]` - Your certificate authority's certificate (or intermediate authorities), if needed.
 
 ### Apache configuration attributes
 
@@ -115,7 +115,7 @@ If `openldap[:manage_ssl]` is `true`, then this cookbook manage your certificate
 Be sure to update the certificate locations in the templates as required. We suggest copying this cookbook to the site-cookbooks for such modifications, so you can still pull from our master for updates, and then merge your changes in.
 
 However, if `openldap[:manage_ssl]` is `false`, then you will need to place the SSL certificates on the client file system **prior** to this cookbook being run. This provides you the flexibility to provide the same set of SSL certificates for multiple uses as well as in one place across your environment, but you will need to manage them.
-- Set `openldap[:ssl-cert]`, `openldap[:ssl_key]`, and `openldap[:cacert]` appropriately.
+- Set `openldap[:ssl_cert]`, `openldap[:ssl_key]`, and `openldap[:cafile]` appropriately.
 - Ensure that that user openldap can access these files. Watch out for apparmor and SELinux if you are placing your SSL certificates in a non-default location.
 
 ### New Directory


### PR DESCRIPTION
...ap[:cafile] instead of openldap[:cacert].