### PR TITLE
Debian using db4.8-util instead of db4.2-util

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -19,7 +19,7 @@
 include_recipe "openldap::client"
 
 case node['platform']
-when "ubuntu"
+when "ubuntu", "debian"
   package "db4.8-util" do
     action :upgrade
   end


### PR DESCRIPTION
Resolve Debian package  error

```
Recipe: openldap::server
  * package[db4.2-util] action upgrade
================================================================================
Error executing action `upgrade` on resource 'package[db4.2-util]'
================================================================================


Chef::Exceptions::Package
-------------------------
db4.2-util has no candidate in the apt-cache
```