### PR TITLE
Add "automount:" and "sudoers:" to nsswitch.conf.

### DIFF
--- a/files/default/nsswitch.conf
+++ b/files/default/nsswitch.conf
@@ -19,3 +19,6 @@ ethers:         db files
 rpc:            db files
 
 netgroup:       nis
+
+automount:      files ldap
+sudoers:        files ldap


### PR DESCRIPTION
Once LDAP authentication is enabled on a client it is also beneficial to pull autofs maps and sudoes configuration from LDAP server.